### PR TITLE
SITE-2337 | Do not require pageimages and textextracts extensions

### DIFF
--- a/includes/PopupsContext.php
+++ b/includes/PopupsContext.php
@@ -207,18 +207,6 @@ class PopupsContext {
 	}
 
 	/**
-	 * @return bool
-	 */
-	public function areDependenciesMet() {
-		if ( $this->config->get( 'PopupsGateway' ) === 'mwApiPlain' ) {
-			return $this->extensionRegistry->isLoaded( 'TextExtracts' )
-			&& $this->extensionRegistry->isLoaded( 'PageImages' );
-		}
-
-		return true;
-	}
-
-	/**
 	 * Whether popups code should be shipped to $title
 	 *
 	 * For example, if 'Special:UserLogin' is excluded, and the user is on 'Special:UserLogin',

--- a/includes/PopupsHooks.php
+++ b/includes/PopupsHooks.php
@@ -148,13 +148,6 @@ class PopupsHooks {
 			return;
 		}
 
-		if ( !$context->areDependenciesMet() ) {
-			$logger = $context->getLogger();
-			$logger->error( 'Popups requires the PageImages extensions.
-				TextExtracts extension is required when using mwApiPlain gateway.' );
-			return;
-		}
-
 		$user = $out->getUser();
 		if ( $context->shouldSendModuleToUser( $user ) ) {
 			$out->addModules( [ 'ext.popups' ] );


### PR DESCRIPTION
https://fandom.atlassian.net/browse/SITE-2337

We don't use them anymore in popups.
This PR is necessary for removing PageImages extension from our platform. 

@Wikia/site-experience 